### PR TITLE
Support PackageInfoFlags and getPackageInfoAsUser overloads for Play Store spoofing

### DIFF
--- a/app/src/main/kotlin/com/mymod/playspoofer/xposed/Hook.kt
+++ b/app/src/main/kotlin/com/mymod/playspoofer/xposed/Hook.kt
@@ -69,7 +69,7 @@ class Hook : IXposedHookLoadPackage {
         }
 
         val packageInfoFlagsClass = try {
-            Class.forName("android.content.pm.PackageManager$PackageInfoFlags")
+            Class.forName("android.content.pm.PackageManager\$PackageInfoFlags")
         } catch (e: ClassNotFoundException) {
             Log.i("PackageInfoFlags 类不存在，跳过对应 Hook")
             null


### PR DESCRIPTION
### Motivation
- Ensure the module intercepts newer `PackageManager` APIs so Play Store’s "About" page (and other callers) read the spoofed `PackageInfo`.
- Add support for `PackageInfoFlags`-based overloads and the `getPackageInfoAsUser` variants across Android versions.
- Reuse existing spoofing logic so version fields are consistently overridden.
- Preserve existing logging and the `hasHookedPlayStore` behavior to avoid noisy repeated logs.

### Description
- Updated `app/src/main/kotlin/com/mymod/playspoofer/xposed/Hook.kt` to detect and reflectively load `PackageManager$PackageInfoFlags` via `Class.forName`.
- Added hooks for the following signatures (with try/catch fallbacks):
  - `getPackageInfo(String, PackageInfoFlags)` and `getPackageInfo(VersionedPackage, PackageInfoFlags)`
  - `getPackageInfoAsUser(String, PackageInfoFlags, int)` with fallback to legacy `getPackageInfoAsUser(String, int, int)`
  - Existing `getPackageInfo(String, int)` and `getPackageInfo(VersionedPackage, int)` remain hooked.
- Generalized the helper to `hookGetPackageInfo` to accept a `methodName` so the same logic can be reused for different overloads.
- Kept the original behavior: extract package name from the first argument, only modify when `com.android.vending` is targeted, log the original/ spoofed versions only on first hit, and set `param.result` to the modified `PackageInfo`.
- Defensive `try/catch` handling added to gracefully skip signatures that do not exist on the running platform.

### Testing
- No automated tests were executed in this change (no test runs requested).
- Manual runtime verification is recommended on target Android versions to confirm Play Store "About" page shows the overridden `PackageInfo` values.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945d74e3bd4832385bc696156e33e51)