### PR TITLE
Harden PackageInfo hooks (add PackageInfoFlags support) and optimize build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,25 +17,22 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
+          fetch-depth: 1
 
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: '19'
+          cache: gradle
 
-      - name: Set up cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('**/buildSrc/**/*.kt') }}
+      - name: Validate Gradle Wrapper
+        uses: gradle/wrapper-validation-action@v3
 
       - name: Build
         run: |
           chmod +x ./gradlew
-          ./gradlew assembleRelease
+          ./gradlew assembleRelease --no-daemon --stacktrace
 
       - name: Upload APK artifact
         uses: actions/upload-artifact@v4

--- a/app/src/main/kotlin/com/mymod/playspoofer/xposed/Hook.kt
+++ b/app/src/main/kotlin/com/mymod/playspoofer/xposed/Hook.kt
@@ -18,6 +18,16 @@ class Hook : IXposedHookLoadPackage {
         /** 标记是否已经在第一次 Hook 成功时打印过日志 */
         @Volatile
         private var hasHookedPlayStore = false
+
+        @Volatile
+        private var hasLoggedFlagsHook = false
+
+        @Volatile
+        private var hasLoggedNullResult = false
+
+        private const val VERSIONED_PACKAGE_CLASS = "android.content.pm.VersionedPackage"
+        private const val PACKAGE_INFO_FLAGS_CLASS = "android.content.pm.PackageManager\$PackageInfoFlags"
+        private const val APP_PACKAGE_MANAGER_CLASS = "android.app.ApplicationPackageManager"
     }
 
     override fun handleLoadPackage(lpparam: LoadPackageParam) {
@@ -50,21 +60,28 @@ class Hook : IXposedHookLoadPackage {
             Log.i("开始 Hook 进程：${lpparam.packageName}")
         }
 
+        if (!ensureApplicationPackageManagerAvailable()) return
+
         // Hook getPackageInfo(String, int)
-        hookGetPackageInfo(
+        hookGetPackageInfoSafely(
             lpparam,
-            arrayOf<Class<*>>(String::class.java, Int::class.javaPrimitiveType!!)
+            arrayOf<Class<*>>(String::class.java, Int::class.javaPrimitiveType!!),
+            "getPackageInfo(String, int)"
+        )
+        // Hook getPackageInfo(String, PackageInfoFlags)
+        hookPackageInfoFlagsOverload(
+            lpparam,
+            String::class.java,
+            "getPackageInfo(String, PackageInfoFlags)"
         )
         // Hook getPackageInfo(VersionedPackage, int)
-        try {
-            val versionedClass = Class.forName("android.content.pm.VersionedPackage")
-            hookGetPackageInfo(
-                lpparam,
-                arrayOf<Class<*>>(versionedClass, Int::class.javaPrimitiveType!!)
-            )
-        } catch (e: ClassNotFoundException) {
-            Log.i("VersionedPackage 类不存在，跳过第二个 Hook")
-        }
+        hookVersionedPackageOverload(
+            lpparam,
+            Int::class.javaPrimitiveType!!,
+            "getPackageInfo(VersionedPackage, int)"
+        )
+        // Hook getPackageInfo(VersionedPackage, PackageInfoFlags)
+        hookVersionedPackageFlagsOverload(lpparam)
     }
 
     /**
@@ -82,30 +99,40 @@ class Hook : IXposedHookLoadPackage {
                 val pkgArg = param.args[0]
                 val pkgName = when (pkgArg) {
                     is String -> pkgArg
-                    else -> XposedHelpers.callMethod(pkgArg, "getPackageName") as? String ?: return
+                    else -> {
+                        if (pkgArg.javaClass.name != VERSIONED_PACKAGE_CLASS) return
+                        XposedHelpers.callMethod(pkgArg, "getPackageName") as? String ?: return
+                    }
                 }
                 if (pkgName != PLAY_STORE_PKG) return
 
                 // 拿到原始 PackageInfo 对象
-                (param.result as? PackageInfo)?.let { pkgInfo ->
-                    if (!hasHookedPlayStore) {
-                        // 第一次进入这里：打印原始版本→伪装版本日志，并设置标志
-                        logVersion("原始版本", pkgInfo)
-                        modifyPackageInfo(pkgInfo)
-                        logVersion("已伪装版本", pkgInfo)
-                        hasHookedPlayStore = true
-                    } else {
-                        // 后续所有调用：只做版本号修改，不再打印日志
-                        modifyPackageInfo(pkgInfo)
+                val pkgInfo = param.result as? PackageInfo
+                if (pkgInfo == null) {
+                    if (!hasLoggedNullResult) {
+                        Log.i("getPackageInfo returned null or unexpected result for $pkgName")
+                        hasLoggedNullResult = true
                     }
-                    // 必须重新赋值回去
-                    param.result = pkgInfo
+                    return
                 }
+
+                if (!hasHookedPlayStore) {
+                    // 第一次进入这里：打印原始版本→伪装版本日志，并设置标志
+                    logVersion("原始版本", pkgInfo)
+                    modifyPackageInfo(pkgInfo)
+                    logVersion("已伪装版本", pkgInfo)
+                    hasHookedPlayStore = true
+                } else {
+                    // 后续所有调用：只做版本号修改，不再打印日志
+                    modifyPackageInfo(pkgInfo)
+                }
+                // 必须重新赋值回去
+                param.result = pkgInfo
             }
         }
 
         XposedHelpers.findAndHookMethod(
-            "android.app.ApplicationPackageManager",
+            APP_PACKAGE_MANAGER_CLASS,
             lpparam.classLoader,
             "getPackageInfo",
             *paramTypes,
@@ -128,9 +155,98 @@ class Hook : IXposedHookLoadPackage {
      * 强制修改 PackageInfo 中的版本号字段为最大值
      */
     private fun modifyPackageInfo(packageInfo: PackageInfo) {
-        packageInfo.apply {
-            longVersionCode = MAX_VERSION_CODE
-            versionName = MAX_VERSION_NAME
+        runCatching { packageInfo.longVersionCode = MAX_VERSION_CODE }
+            .onFailure {
+                runCatching {
+                    XposedHelpers.setLongField(packageInfo, "longVersionCode", MAX_VERSION_CODE)
+                }
+            }
+
+        runCatching { packageInfo.versionName = MAX_VERSION_NAME }
+            .onFailure {
+                runCatching {
+                    XposedHelpers.setObjectField(packageInfo, "versionName", MAX_VERSION_NAME)
+                }
+            }
+    }
+
+    private fun ensureApplicationPackageManagerAvailable(): Boolean {
+        return runCatching {
+            Class.forName(APP_PACKAGE_MANAGER_CLASS)
+        }.onFailure { error ->
+            Log.i("ApplicationPackageManager not available: ${error.javaClass.simpleName}: ${error.message}")
+        }.isSuccess
+    }
+
+    private fun hookGetPackageInfoSafely(
+        lpparam: LoadPackageParam,
+        paramTypes: Array<Class<*>>,
+        signatureLabel: String
+    ) {
+        runCatching {
+            hookGetPackageInfo(lpparam, paramTypes)
+        }.onFailure { error ->
+            Log.i("$signatureLabel hook not available: ${error.javaClass.simpleName}: ${error.message}")
         }
+    }
+
+    private fun hookPackageInfoFlagsOverload(
+        lpparam: LoadPackageParam,
+        packageNameClass: Class<*>,
+        signatureLabel: String
+    ) {
+        val flagsClass = resolveClass(PACKAGE_INFO_FLAGS_CLASS)
+        if (flagsClass == null) {
+            Log.i("$signatureLabel hook not available: PackageInfoFlags class missing")
+            return
+        }
+        hookGetPackageInfoSafely(
+            lpparam,
+            arrayOf(packageNameClass, flagsClass),
+            signatureLabel
+        )
+        if (!hasLoggedFlagsHook) {
+            Log.i("PackageInfoFlags overload detected, enabling flags-based hook")
+            hasLoggedFlagsHook = true
+        }
+    }
+
+    private fun hookVersionedPackageOverload(
+        lpparam: LoadPackageParam,
+        flagType: Class<*>,
+        signatureLabel: String
+    ) {
+        val versionedClass = resolveClass(VERSIONED_PACKAGE_CLASS)
+        if (versionedClass == null) {
+            Log.i("VersionedPackage 类不存在，跳过 Hook")
+            return
+        }
+        hookGetPackageInfoSafely(
+            lpparam,
+            arrayOf(versionedClass, flagType),
+            signatureLabel
+        )
+    }
+
+    private fun hookVersionedPackageFlagsOverload(lpparam: LoadPackageParam) {
+        val versionedClass = resolveClass(VERSIONED_PACKAGE_CLASS)
+        val flagsClass = resolveClass(PACKAGE_INFO_FLAGS_CLASS)
+        if (versionedClass == null || flagsClass == null) {
+            Log.i("getPackageInfo(VersionedPackage, PackageInfoFlags) hook not available: missing class")
+            return
+        }
+        hookGetPackageInfoSafely(
+            lpparam,
+            arrayOf(versionedClass, flagsClass),
+            "getPackageInfo(VersionedPackage, PackageInfoFlags)"
+        )
+        if (!hasLoggedFlagsHook) {
+            Log.i("PackageInfoFlags overload detected, enabling flags-based hook")
+            hasLoggedFlagsHook = true
+        }
+    }
+
+    private fun resolveClass(className: String): Class<*>? {
+        return runCatching { Class.forName(className) }.getOrNull()
     }
 }


### PR DESCRIPTION
### Motivation
- Google Play Store started calling `getPackageInfo` overloads that accept `PackageInfoFlags`, which bypassed the existing `int`-based hooks and caused spoofing to fail.
- Direct field writes to `PackageInfo` can be blocked on some Android 13+/custom ROMs, so a reflective fallback is needed to ensure mutation succeeds.
- Repeated `Class.forName` lookups and unguarded hook installs risk crashes and make behavior harder to observe across ROMs.
- CI build workflow can be made safer and faster by enabling Gradle caching, wrapper validation, and more deterministic Gradle flags.

### Description
- Add hooks for `getPackageInfo(String, PackageInfoFlags)` and `getPackageInfo(VersionedPackage, PackageInfoFlags)` and keep existing `int` overload hooks by invoking the same `hookGetPackageInfo` helper.
- Harden `hookGetPackageInfo` and related logic with `ensureApplicationPackageManagerAvailable()` and safety helpers `hookGetPackageInfoSafely`, `hookPackageInfoFlagsOverload`, `hookVersionedPackageOverload`, `hookVersionedPackageFlagsOverload`, and `resolveClass` to avoid repeated reflection and silent crashes.
- Improve observability by emitting one-time logs for detected `PackageInfoFlags` overloads and when `getPackageInfo` returns a null/unexpected result, and restrict `VersionedPackage` handling to verified class names.
- Use reflective fallbacks in `modifyPackageInfo` to set `longVersionCode` and `versionName` when direct assignment fails, and update CI workflow `.github/workflows/build.yaml` to set `fetch-depth: 1`, enable `cache: gradle` for `setup-java`, add `gradle/wrapper-validation-action@v3`, and run `./gradlew assembleRelease --no-daemon --stacktrace`.

### Testing
- No automated tests were run for these changes.
- The workflow modification is a CI configuration change and was not executed as part of this PR.
- Runtime/behavioral verification was not performed in CI; one-time logs were added to assist manual runtime validation.
- If desired, a small smoke test or CI job to build and run a basic instrumentation can be added on request.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69460c52079c8323aae051b1b59b5f4f)